### PR TITLE
Update README.md - tool is not maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# NOTE: As of 2023 this tool is no longer maintained or supported.
+
 # BagIt Splitting and Unsplitting Tools
 
 ## Overview


### PR DESCRIPTION
We're doing some MetaArchive documentation cleanup, and I want to make sure folks know that this tool is no longer maintained or functional.  

For more, please see: https://confluence.educopia.org/display/MET/Bag+Split+Utility